### PR TITLE
Bump IMDG version to 4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <hazelcast.version>4.0.3</hazelcast.version>
+        <hazelcast.version>4.1</hazelcast.version>
     </properties>
 
     <build>
@@ -70,6 +70,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/hazelcast.yaml
+++ b/src/test/resources/hazelcast.yaml
@@ -1,0 +1,8 @@
+hazelcast:
+  cluster-name: hazelcast-cluster
+  network:
+    join:
+      auto-detection:
+        enabled: false
+      multicast:
+        enabled: true

--- a/src/test/resources/hazelcast.yaml
+++ b/src/test/resources/hazelcast.yaml
@@ -2,7 +2,5 @@ hazelcast:
   cluster-name: hazelcast-cluster
   network:
     join:
-      auto-detection:
-        enabled: false
       multicast:
         enabled: true


### PR DESCRIPTION
Adds `json-smart` explicitly in test scope. Otherwise, `json-path` comes with hazelcast-all-v4.1 excludes `json-smart` which is needed by the current integration tests:

with v4.0.3 hazelcast-all:
```
[INFO] +- com.hazelcast:hazelcast-all:jar:4.0.3:compile
[INFO] +- org.springframework.boot:spring-boot-starter-test:jar:2.3.5.RELEASE:test
[INFO] |  +- org.springframework.boot:spring-boot-test:jar:2.3.5.RELEASE:test
[INFO] |  +- org.springframework.boot:spring-boot-test-autoconfigure:jar:2.3.5.RELEASE:test
[INFO] |  +- com.jayway.jsonpath:json-path:jar:2.4.0:test
[INFO] |  |  +- net.minidev:json-smart:jar:2.3:test <<<<<<<<<<<<<<<<<<<
[INFO] |  |  |  \- net.minidev:accessors-smart:jar:1.2:test
[INFO] |  |  |     \- org.ow2.asm:asm:jar:5.0.4:test
[INFO] |  |  \- org.slf4j:slf4j-api:jar:1.7.30:compile
```

with v4.1 hazelcast-all:
```
[INFO] +- com.hazelcast:hazelcast-all:jar:4.1:compile
[INFO] |  +- org.apache.calcite:calcite-core:jar:1.23.0:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-core:jar:2.11.3:compile
[INFO] |  |  \- org.apache.commons:commons-lang3:jar:3.10:runtime
[INFO] |  +- org.apache.calcite:calcite-linq4j:jar:1.23.0:compile
[INFO] |  +- org.apache.calcite.avatica:avatica-core:jar:1.16.0:compile
[INFO] |  +- com.jayway.jsonpath:json-path:jar:2.4.0:runtime  <<<<<<<<<<<<<<<<<<<
[INFO] |  +- commons-codec:commons-codec:jar:1.14:runtime

```