### PR TITLE
Remove Hazelcast version from the guide text

### DIFF
--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -32,7 +32,6 @@ If Hazelcast is on the classpath and a suitable configuration is found, Spring B
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-all</artifactId>
-    <version>4.0.2</version>
 </dependency>
 ----
 


### PR DESCRIPTION
It's hard to maintain and easy to forget to update it.